### PR TITLE
Fix/android/purchase when user already subscribed

### DIFF
--- a/Android/cam/build.gradle
+++ b/Android/cam/build.gradle
@@ -9,8 +9,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 18
-        versionName "4.3.0"
+        versionCode 19
+        versionName "4.4.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/Android/cam/gradle.properties
+++ b/Android/cam/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.applicaster
 ARTIFACT_ID=applicaster-cam-framework
-VERSION=4.3.0
+VERSION=4.4.0
 
 POM_DESCRIPTION=Content Access Manager framework
 POM_URL=https://github.com/applicaster/applicaster-cam-framework.git

--- a/Android/cam/src/main/java/com/applicaster/cam/ui/auth/user/UserAuthPresenter.kt
+++ b/Android/cam/src/main/java/com/applicaster/cam/ui/auth/user/UserAuthPresenter.kt
@@ -88,7 +88,12 @@ abstract class UserAuthPresenter(private val view: IBaseInputView?) : BaseInputP
 
     protected fun navigateOnAuthSuccess(navigationRouter: CamNavigationRouter) {
         when (ContentAccessManager.camFlow) {
-            CamFlow.AUTH_AND_STOREFRONT, CamFlow.STOREFRONT -> navigationRouter.attachBillingFragment()
+            CamFlow.AUTH_AND_STOREFRONT, CamFlow.STOREFRONT -> {
+                if (ContentAccessManager.contract.isPurchaseRequired())
+                    navigationRouter.attachBillingFragment()
+                else
+                    view?.close()
+            }
             else -> view?.close()
         }
     }


### PR DESCRIPTION
The issue related to https://applicaster.atlassian.net/browse/MRP-585 tiket.
Added check if user subscribed after login to prevent opening storefront screen. Because CAM flow was set before login and right before opening login or sign-up screen and didn't change after getting subscription information. Was added check, if user subscribed after login, to logic of opening the next screen.