### PR TITLE
IM-659: [Android] Coroutines updated to 1.3.6 to match 13.x+ SDK

### DIFF
--- a/Android/cam/build.gradle
+++ b/Android/cam/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 28
         versionCode 22
-        versionName "4.4.3"
+        versionName "4.5.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
@@ -69,8 +69,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
-    api 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3'
-    api "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.27.0-eap13"
+    api 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.6'
+    api "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.6"
 }
 
 //---------------------------------- Bintray ----------------------------------//


### PR DESCRIPTION
 Coroutines updated to 1.3.6 to match 13.x+ SDK.Version updated to 4.5.0
https://applicaster.atlassian.net/browse/IM-659