### PR TITLE
Fix config fetcher

### DIFF
--- a/Android/zapp-config-fetcher/src/main/java/com/applicaster/zapp/configfetcher/UIExecutor.kt
+++ b/Android/zapp-config-fetcher/src/main/java/com/applicaster/zapp/configfetcher/UIExecutor.kt
@@ -2,6 +2,7 @@ package com.applicaster.zapp.configfetcher
 
 import android.content.Context
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.Lifecycle
 import com.applicaster.zapp.configfetcher.ui.TransparentLoadingFragment
 
 fun FragmentActivity.showLoading() {
@@ -31,11 +32,14 @@ class UIEnvironment(context: Context?, showLoadingUI: Boolean){
     suspend fun <T> executeWithResult(
             function: suspend () -> T
     ): T {
-        activity?.run { if(!activity.isFinishing) showLoading() }
+        activity?.run { if(isVisible(activity)) showLoading() }
         val data = function()
-        activity?.run { if(!activity.isFinishing) hideLoading() }
+        activity?.run { if(isVisible(activity)) hideLoading() }
         return data
     }
+
+    private fun isVisible(activity: FragmentActivity) =
+            activity.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
 
     suspend fun execute(
             function: suspend () -> Unit


### PR DESCRIPTION
Cam library had issues with delayed callbacks: activity could be already paused or destroyed, but UIExecuter tried to hide progress fragment overlay.
Easiest repo step: press home on intro activity during first app startup.
Its not the best fix (in theory we can show progress over any activity in paused state, and miss hide callback on resume), so we need live data or something, but in our case its only been called on Intro activity, so we don't really care.

One of the two crashes in [https://applicaster.atlassian.net/browse/TPS-287](https://applicaster.atlassian.net/browse/TPS-287)

Crash call stack:

`androidx.fragment.app.FragmentManagerImpl.checkStateLoss
FragmentManagerImpl.java, line 1536
java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
androidx.fragment.app.FragmentManagerImpl.checkStateLoss FragmentManagerImpl.java:1536
androidx.fragment.app.FragmentManagerImpl.enqueueAction FragmentManagerImpl.java:1558
androidx.fragment.app.BackStackRecord.commitInternal BackStackRecord.java:317
androidx.fragment.app.BackStackRecord.commit BackStackRecord.java:282
com.applicaster.zapp.configfetcher.UIExecutorKt.showLoading UIExecutorKt.java:33
com.applicaster.zapp.configfetcher.UIExecutorKt.executeWithResult UIExecutorKt.java:10
com.applicaster.zapp.configfetcher.ZappConfigFetcher.loadFullConfig ZappConfigFetcher.java:19
com.applicaster.cleeng.CleengLoginPlugin.loadPluginConfig CleengLoginPlugin.java:103
com.applicaster.cleeng.CleengLoginPlugin$executeOnStartup$1.invokeSuspend CleengLoginPlugin.java:32
com.applicaster.cleeng.CleengLoginPlugin$executeOnStartup$1.invoke CleengLoginPlugin.java:10
com.applicaster.cleeng.network.RequestExecutorKt$executeRequest$1.invokeSuspend RequestExecutorKt.java:38
kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith BaseContinuationImpl.java:33
kotlinx.coroutines.DispatchedTask.run DispatchedTask.java:56
android.os.Handler.handleCallback Handler.java:873`