### PR TITLE
Fix crash on null container_bottom_links

### DIFF
--- a/Android/cam/gradle.properties
+++ b/Android/cam/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.applicaster
 ARTIFACT_ID=applicaster-cam-framework
-VERSION=4.6.0
+VERSION=4.6.1
 
 POM_DESCRIPTION=Content Access Manager framework
 POM_URL=https://github.com/applicaster/applicaster-cam-framework.git

--- a/Android/cam/src/main/java/com/applicaster/cam/ui/billing/BillingFragment.kt
+++ b/Android/cam/src/main/java/com/applicaster/cam/ui/billing/BillingFragment.kt
@@ -145,7 +145,7 @@ class BillingFragment : BaseFragment(), IBillingView {
     }
 
     override fun hideCustomLinksContainer() {
-        container_bottom_links.visibility = View.GONE
+        container_bottom_links?.visibility = View.GONE
     }
 
     override fun clearBillingContainer() {


### PR DESCRIPTION
Fix for https://applicaster.atlassian.net/browse/TPS-287
Bump CAM version to 4.6.1

Real reason most likely is missing proper handling of fragment lifecycle while performing async operations, but fixing in require rewriting a lot of code.