### PR TITLE
fix: Allow to restore items that are not currenty offered

### DIFF
--- a/Android/cam/gradle.properties
+++ b/Android/cam/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.applicaster
 ARTIFACT_ID=applicaster-cam-framework
-VERSION=4.6.1
+VERSION=4.6.2
 
 POM_DESCRIPTION=Content Access Manager framework
 POM_URL=https://github.com/applicaster/applicaster-cam-framework.git

--- a/Android/cam/src/main/java/com/applicaster/cam/ui/billing/BillingPresenter.kt
+++ b/Android/cam/src/main/java/com/applicaster/cam/ui/billing/BillingPresenter.kt
@@ -171,8 +171,8 @@ class BillingPresenter(
                 purchases.find { purchase -> details.sku == purchase.sku } != null
             }
             if (isNonMatchingRestoredPurchasesExists) {
-                showHandledError(ContentAccessManager.pluginConfigurator.getNonMatchingRestoredPurchasesText())
-                purchaseSucceed = true
+                // not an error
+                Log.i(TAG, "Restored legacy item")
             }
         }
         return purchaseSucceed


### PR DESCRIPTION
Right now cleeng plugin only loads information for currently available offers, but restore flow checks item restored agains that list. So, if user had some purchase before, and its not available anymore for new purchases, he would not be able to restore it, that is agains Play guidelines. Better fix would be to actually load this information but its only needed for single time per item purchases.