### PR TITLE
Fix error message

### DIFF
--- a/Android/cam/gradle.properties
+++ b/Android/cam/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.applicaster
 ARTIFACT_ID=applicaster-cam-framework
-VERSION=4.6.2
+VERSION=4.6.3
 
 POM_DESCRIPTION=Content Access Manager framework
 POM_URL=https://github.com/applicaster/applicaster-cam-framework.git

--- a/Android/cam/src/main/java/com/applicaster/cam/ui/auth/password/reset/PasswordResetPresenter.kt
+++ b/Android/cam/src/main/java/com/applicaster/cam/ui/auth/password/reset/PasswordResetPresenter.kt
@@ -1,5 +1,6 @@
 package com.applicaster.cam.ui.auth.password.reset
 
+import android.util.Log
 import com.applicaster.cam.ContentAccessManager
 import com.applicaster.cam.PasswordResetCallback
 import com.applicaster.cam.SendPasswordActivationCodeCallback
@@ -18,6 +19,8 @@ class PasswordResetPresenter(
     private val navigationRouter: CamNavigationRouter
 ) :
     BaseInputPresenter(view), IBaseInputPresenter, PasswordResetCallback, SendPasswordActivationCodeCallback {
+
+    private val TAG = "PasswordResetPresenter"
 
     override fun onViewCreated() {
         super.onViewCreated()
@@ -44,6 +47,7 @@ class PasswordResetPresenter(
     }
 
     override fun onFailure(msg: String) {
+        Log.e(TAG, "onFailure: $msg")
         view?.hideLoadingIndicator()
         view?.showAlert(msg)
         //Analytics

--- a/Android/cam/src/main/java/com/applicaster/cam/ui/auth/password/update/PasswordUpdatePresenter.kt
+++ b/Android/cam/src/main/java/com/applicaster/cam/ui/auth/password/update/PasswordUpdatePresenter.kt
@@ -1,5 +1,6 @@
 package com.applicaster.cam.ui.auth.password.update
 
+import android.util.Log
 import com.applicaster.cam.ContentAccessManager
 import com.applicaster.cam.PasswordUpdateCallback
 import com.applicaster.cam.analytics.AnalyticsUtil
@@ -18,6 +19,8 @@ class PasswordUpdatePresenter(
 ) :
     BaseInputPresenter(view), IBaseInputPresenter, PasswordUpdateCallback {
 
+    private val TAG = "PasswordUpdatePresenter"
+
     override fun onViewCreated() {
         super.onViewCreated()
 
@@ -29,6 +32,7 @@ class PasswordUpdatePresenter(
     }
 
     override fun onFailure(msg: String) {
+        Log.e(TAG, "onFailure: $msg")
         view?.hideLoadingIndicator()
         view?.showAlert(msg)
     }

--- a/Android/cam/src/main/java/com/applicaster/cam/ui/auth/user/activation/AccountActivationPresenter.kt
+++ b/Android/cam/src/main/java/com/applicaster/cam/ui/auth/user/activation/AccountActivationPresenter.kt
@@ -1,5 +1,6 @@
 package com.applicaster.cam.ui.auth.user.activation
 
+import android.util.Log
 import com.applicaster.cam.AccountActivationCallback
 import com.applicaster.cam.CamFlow
 import com.applicaster.cam.SendAuthActivationCodeCallback
@@ -19,6 +20,8 @@ class AccountActivationPresenter(
 ) :
     BaseInputPresenter(view), IAccountActivationPresenter, SendAuthActivationCodeCallback,
     AccountActivationCallback {
+
+    private val TAG = "AccountActivationPresenter"
 
     override fun onViewCreated() {
         super.onViewCreated()
@@ -45,6 +48,7 @@ class AccountActivationPresenter(
     }
 
     override fun onFailure(msg: String) {
+        Log.e(TAG, "onFailure: $msg")
         view?.hideLoadingIndicator()
         view?.showAlert(msg)
     }

--- a/Android/cam/src/main/java/com/applicaster/cam/ui/auth/user/login/LoginPresenter.kt
+++ b/Android/cam/src/main/java/com/applicaster/cam/ui/auth/user/login/LoginPresenter.kt
@@ -2,9 +2,7 @@ package com.applicaster.cam.ui.auth.user.login
 
 import android.app.Activity
 import android.content.ActivityNotFoundException
-import android.content.Intent
-import androidx.core.content.ContextCompat
-import com.applicaster.cam.CamFlow
+import android.util.Log
 import com.applicaster.cam.ContentAccessManager
 import com.applicaster.cam.FacebookAuthCallback
 import com.applicaster.cam.LoginCallback
@@ -15,13 +13,15 @@ import com.applicaster.cam.params.auth.AuthScreenType
 import com.applicaster.cam.ui.CamNavigationRouter
 import com.applicaster.cam.ui.auth.user.UserAuthPresenter
 import com.applicaster.cam.ui.base.presenter.ICustomLinkActionHandler
-import java.lang.NullPointerException
 
 class LoginPresenter(
     private val view: ILoginView?,
     private val navigationRouter: CamNavigationRouter
 ) :
     UserAuthPresenter(view), ILoginPresenter, LoginCallback, FacebookAuthCallback, ICustomLinkActionHandler {
+
+    private val TAG = "LoginPresenter"
+
     private val userInput: HashMap<String, String> = hashMapOf()
 
     override fun onViewCreated() {
@@ -54,6 +54,7 @@ class LoginPresenter(
     }
 
     override fun onFacebookAuthFailure(msg: String) {
+        Log.e(TAG, "onFacebookAuthFailure: $msg")
         view?.hideLoadingIndicator()
         view?.showAlert(msg)
         AnalyticsUtil.logAlternativeLoginFailure()
@@ -76,6 +77,7 @@ class LoginPresenter(
     }
 
     override fun onFailure(msg: String) {
+        Log.e(TAG, "onFailure: $msg")
         view?.hideLoadingIndicator()
         view?.showAlert(msg)
         //Analytics

--- a/Android/cam/src/main/java/com/applicaster/cam/ui/billing/BillingPresenter.kt
+++ b/Android/cam/src/main/java/com/applicaster/cam/ui/billing/BillingPresenter.kt
@@ -27,7 +27,7 @@ class BillingPresenter(
         IBillingPresenter,
         BillingListener, RestoreCallback {
 
-    private val TAG = BillingPresenter::class.java.canonicalName
+    private val TAG = "BillingPresenter"
 
     private val skuDetailsList: ArrayList<SkuDetails> = arrayListOf()
     private val camContract: ICamContract = ContentAccessManager.contract
@@ -69,6 +69,7 @@ class BillingPresenter(
     }
 
     override fun onBillingClientError(statusCode: Int, description: String) {
+        Log.e(TAG, "onBillingClientError: $statusCode $description")
         view?.hideLoadingIndicator()
         view?.showAlert(ContentAccessManager.pluginConfigurator.getDefaultAlertText())
     }
@@ -265,6 +266,7 @@ class BillingPresenter(
     }
 
     private fun showHandledError(description: String = "", apiMsg: String = "") {
+        Log.e(TAG, "Handled error: $description  $apiMsg")
         view?.showAlert(
                 if (description.isEmpty())
                     ContentAccessManager.pluginConfigurator.getDefaultAlertText()
@@ -285,6 +287,7 @@ class BillingPresenter(
      * Restore action failed on Cleeng side
      */
     override fun onFailure(msg: String) {
+        Log.e(TAG, "onFailure: $msg")
         view?.hideLoadingIndicator()
         view?.showAlert(msg)
         sendRestoreFailureAnalytics(msg)

--- a/Android/cam/src/main/java/com/applicaster/cam/ui/billing/BillingPresenter.kt
+++ b/Android/cam/src/main/java/com/applicaster/cam/ui/billing/BillingPresenter.kt
@@ -266,10 +266,10 @@ class BillingPresenter(
 
     private fun showHandledError(description: String = "", apiMsg: String = "") {
         view?.showAlert(
-                if (apiMsg.isEmpty())
+                if (description.isEmpty())
                     ContentAccessManager.pluginConfigurator.getDefaultAlertText()
                 else
-                    apiMsg
+                    description
         )
         // Analytics events
         AnalyticsUtil.logViewAlert(ConfirmationAlertData(


### PR DESCRIPTION
Error message for the user was taken from wrong argument. Second arguments is actually always empty.
Error logging added, where possible.